### PR TITLE
fix formatting by running cargo fmt

### DIFF
--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -283,7 +283,7 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
             None,
             None,
             None,
-            None
+            None,
         )
         .map_err(|e| format!("Unable to create new validator definition: {:?}", e))?;
 

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -141,7 +141,7 @@ impl ValidatorDefinition {
         gas_limit: Option<u64>,
         builder_proposals: Option<bool>,
         builder_pubkey_override: Option<PublicKeyBytes>,
-        builder_timestamp_override: Option<u64>
+        builder_timestamp_override: Option<u64>,
     ) -> Result<Self, Error> {
         let voting_keystore_path = voting_keystore_path.as_ref().into();
         let keystore =
@@ -709,7 +709,8 @@ mod tests {
             voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
             "#;
 
-        let def: ValidatorDefinition = serde_yaml::from_str(valid_builder_timestamp_override).unwrap();
+        let def: ValidatorDefinition =
+            serde_yaml::from_str(valid_builder_timestamp_override).unwrap();
         assert_eq!(def.builder_timestamp_override, Some(1684308220));
     }
 }

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -468,7 +468,7 @@ impl ValidatorClientHttpClient {
         gas_limit: Option<u64>,
         builder_proposals: Option<bool>,
         builder_pubkey_override: Option<PublicKeyBytes>,
-        builder_timestamp_override: Option<u64>
+        builder_timestamp_override: Option<u64>,
     ) -> Result<(), Error> {
         let mut path = self.server.full.clone();
 

--- a/common/eth2/src/lighthouse_vc/types.rs
+++ b/common/eth2/src/lighthouse_vc/types.rs
@@ -96,7 +96,7 @@ pub struct ValidatorPatchRequest {
     pub builder_pubkey_override: Option<PublicKeyBytes>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub builder_timestamp_override: Option<u64>
+    pub builder_timestamp_override: Option<u64>,
 }
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
@@ -121,7 +121,7 @@ pub struct KeystoreValidatorsPostRequest {
     pub builder_pubkey_override: Option<PublicKeyBytes>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub builder_timestamp_override: Option<u64>
+    pub builder_timestamp_override: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -442,9 +442,7 @@ fn builder_registration_pubkey_override_flag() {
     CommandLineTest::new()
         .flag("builder-registration-pubkey-override", Some("100"))
         .run()
-        .with_config(|config| {
-            assert_eq!(config.builder_registration_pubkey_override, Some(100))
-        });
+        .with_config(|config| assert_eq!(config.builder_registration_pubkey_override, Some(100)));
 }
 #[test]
 fn builder_registration_timestamp_override_flag() {

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -1,5 +1,6 @@
 use crate::graffiti_file::GraffitiFile;
 use crate::{http_api, http_metrics};
+use bls::blst_implementations::PublicKeyBytes;
 use clap::ArgMatches;
 use clap_utils::{flags::DISABLE_MALLOC_TUNING_FLAG, parse_optional, parse_required};
 use directory::{
@@ -14,7 +15,6 @@ use std::fs;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::time::Duration;
-use bls::blst_implementations::PublicKeyBytes;
 use types::{Address, GRAFFITI_BYTES_LEN};
 
 pub const DEFAULT_BEACON_NODE: &str = "http://localhost:5052/";

--- a/validator_client/src/http_api/create_validator.rs
+++ b/validator_client/src/http_api/create_validator.rs
@@ -143,7 +143,7 @@ pub async fn create_validators_mnemonic<P: AsRef<Path>, T: 'static + SlotClock, 
                 request.gas_limit,
                 request.builder_proposals,
                 request.builder_pubkey_override,
-                request.builder_timestamp_override
+                request.builder_timestamp_override,
             )
             .await
             .map_err(|e| {

--- a/validator_client/src/http_api/keystores.rs
+++ b/validator_client/src/http_api/keystores.rs
@@ -208,7 +208,7 @@ fn import_single_keystore<T: SlotClock + 'static, E: EthSpec>(
             None,
             None,
             None,
-            None
+            None,
         ))
         .map_err(|e| format!("failed to initialize validator: {:?}", e))?;
 

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -530,7 +530,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                     gas_limit,
                                     builder_proposals,
                                     builder_pubkey_override,
-                                    builder_timestamp_override
+                                    builder_timestamp_override,
                                 ))
                                 .map_err(|e| {
                                     warp_utils::reject::custom_server_error(format!(
@@ -653,7 +653,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                             body.gas_limit,
                                             body.builder_proposals,
                                             body.builder_pubkey_override,
-                                            body.builder_timestamp_override
+                                            body.builder_timestamp_override,
                                         ),
                                     )
                                     .map_err(|e| {

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -540,7 +540,14 @@ impl ApiTester {
         let validator = &self.client.get_lighthouse_validators().await.unwrap().data[index];
 
         self.client
-            .patch_lighthouse_validators(&validator.voting_pubkey, Some(enabled), None, None, None, None)
+            .patch_lighthouse_validators(
+                &validator.voting_pubkey,
+                Some(enabled),
+                None,
+                None,
+                None,
+                None,
+            )
             .await
             .unwrap();
 
@@ -582,7 +589,14 @@ impl ApiTester {
         let validator = &self.client.get_lighthouse_validators().await.unwrap().data[index];
 
         self.client
-            .patch_lighthouse_validators(&validator.voting_pubkey, None, Some(gas_limit), None, None, None)
+            .patch_lighthouse_validators(
+                &validator.voting_pubkey,
+                None,
+                Some(gas_limit),
+                None,
+                None,
+                None,
+            )
             .await
             .unwrap();
 
@@ -610,7 +624,7 @@ impl ApiTester {
                 None,
                 Some(builder_proposals),
                 None,
-                None
+                None,
             )
             .await
             .unwrap();
@@ -630,7 +644,11 @@ impl ApiTester {
         self
     }
 
-    pub async fn set_builder_pubkey_override(self, index: usize, builder_pubkey_override: PublicKeyBytes) -> Self {
+    pub async fn set_builder_pubkey_override(
+        self,
+        index: usize,
+        builder_pubkey_override: PublicKeyBytes,
+    ) -> Self {
         let validator = &self.client.get_lighthouse_validators().await.unwrap().data[index];
 
         self.client
@@ -640,7 +658,7 @@ impl ApiTester {
                 None,
                 None,
                 Some(builder_pubkey_override),
-                None
+                None,
             )
             .await
             .unwrap();
@@ -648,7 +666,11 @@ impl ApiTester {
         self
     }
 
-    pub async fn assert_builder_pubkey_override(self, index: usize, builder_pubkey_override: PublicKeyBytes) -> Self {
+    pub async fn assert_builder_pubkey_override(
+        self,
+        index: usize,
+        builder_pubkey_override: PublicKeyBytes,
+    ) -> Self {
         let validator = &self.client.get_lighthouse_validators().await.unwrap().data[index];
 
         assert_eq!(
@@ -660,7 +682,11 @@ impl ApiTester {
         self
     }
 
-    pub async fn set_builder_timestamp_override(self, index: usize, builder_timestamp_override: u64) -> Self {
+    pub async fn set_builder_timestamp_override(
+        self,
+        index: usize,
+        builder_timestamp_override: u64,
+    ) -> Self {
         let validator = &self.client.get_lighthouse_validators().await.unwrap().data[index];
 
         self.client
@@ -670,7 +696,7 @@ impl ApiTester {
                 None,
                 None,
                 None,
-                Some(builder_timestamp_override)
+                Some(builder_timestamp_override),
             )
             .await
             .unwrap();
@@ -678,7 +704,11 @@ impl ApiTester {
         self
     }
 
-    pub async fn assert_builder_timestamp_override(self, index: usize, builder_timestamp_override: u64) -> Self {
+    pub async fn assert_builder_timestamp_override(
+        self,
+        index: usize,
+        builder_timestamp_override: u64,
+    ) -> Self {
         let validator = &self.client.get_lighthouse_validators().await.unwrap().data[index];
 
         assert_eq!(

--- a/validator_client/src/initialized_validators.rs
+++ b/validator_client/src/initialized_validators.rs
@@ -146,9 +146,13 @@ impl InitializedValidator {
         self.builder_proposals
     }
 
-    pub fn get_builder_pubkey_override(&self) -> Option<PublicKeyBytes> { self.builder_pubkey_override }
+    pub fn get_builder_pubkey_override(&self) -> Option<PublicKeyBytes> {
+        self.builder_pubkey_override
+    }
 
-    pub fn get_builder_timestamp_override(&self) -> Option<u64> { self.builder_timestamp_override }
+    pub fn get_builder_timestamp_override(&self) -> Option<u64> {
+        self.builder_timestamp_override
+    }
 
     pub fn get_index(&self) -> Option<u64> {
         self.index
@@ -716,7 +720,7 @@ impl InitializedValidators {
         gas_limit: Option<u64>,
         builder_proposals: Option<bool>,
         builder_pubkey_override: Option<PublicKeyBytes>,
-        builder_timestamp_override: Option<u64>
+        builder_timestamp_override: Option<u64>,
     ) -> Result<(), Error> {
         if let Some(def) = self
             .definitions

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -187,7 +187,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
             gas_limit,
             builder_proposals,
             builder_pubkey_override,
-            builder_timestamp_override
+            builder_timestamp_override,
         )
         .map_err(|e| format!("failed to create validator definitions: {:?}", e))?;
 
@@ -464,20 +464,26 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
     }
 
     fn get_builder_proposals_defaulting(&self, builder_proposals: Option<bool>) -> bool {
-        builder_proposals
-            .unwrap_or(self.builder_proposals)
+        builder_proposals.unwrap_or(self.builder_proposals)
     }
 
     /// Returns the public key override for the given public key that denotes whether this validator should override
     /// the given public key with the returned value.
-    pub fn get_builder_pubkey_override(&self, validator_pubkey: &PublicKeyBytes) -> Option<PublicKeyBytes> {
-       self.validators.read().builder_pubkey_override(validator_pubkey)
+    pub fn get_builder_pubkey_override(
+        &self,
+        validator_pubkey: &PublicKeyBytes,
+    ) -> Option<PublicKeyBytes> {
+        self.validators
+            .read()
+            .builder_pubkey_override(validator_pubkey)
     }
 
     /// Returns the timestamp override for the given public key that denotes whether this validator should override
     /// the given timestamp with the returned value.
     pub fn get_builder_timestamp_override(&self, validator_pubkey: &PublicKeyBytes) -> Option<u64> {
-        self.validators.read().builder_timestamp_override(validator_pubkey)
+        self.validators
+            .read()
+            .builder_timestamp_override(validator_pubkey)
     }
 
     pub async fn sign_block<Payload: AbstractExecPayload<E>>(
@@ -678,8 +684,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
 
         // Use the provided pubkey rather than the pubkey in the message itself. This is to support
         // distributed validators who must sign with a partial key over the aggregate pubkey.
-        let signing_method =
-            self.doppelganger_bypassed_signing_method(signing_pubkey)?;
+        let signing_method = self.doppelganger_bypassed_signing_method(signing_pubkey)?;
         let signature = signing_method
             .get_signature_from_root::<E, BlindedPayload<E>>(
                 SignableMessage::ValidatorRegistration(&validator_registration_data),


### PR DESCRIPTION
## Issue Addressed

Fixes formatting issues.

## Proposed Changes

Run `cargo fmt` to fix formatting errors.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
